### PR TITLE
Option to blacklist devices by regex

### DIFF
--- a/automount
+++ b/automount
@@ -125,6 +125,14 @@ BLACKLIST (unset by default)
 
   example: BLACKLIST='da0 da3s1a'
 
+BLACKLIST_REGEX (unset by default)
+  The boolean flag option complements the above BLACKLIST option 
+  if one wants regex match instead of exact match for ignoring devices
+  
+  example: BLACKLIST='ada0'
+           BLACKLIST_REGEX=true
+         will ignore all partitions ada0p1, ada0p2 of device ada0 
+
 USER (root by default)
   If set to some username, the mount command will
   chown(1) the mount directory with the user and
@@ -478,6 +486,10 @@ case ${2} in
         if [ "${1}" = "${I}" ]
         then
           __log "${DEV}: device blocked by BLACKLIST option"
+          exit 0
+        elif [ -n "${BLACKLIST_REGEX}" ]  &&  echo ${DEV} | grep -q "${I}"  
+        then
+          __log "${DEV}: device blocked by BLACKLIST regex option"  
           exit 0
         fi
       done


### PR DESCRIPTION
I noticed automount received each partition as a device node. To black list entire device from mounting one needs to lists all partitions as part of BLACKLIST option. I am proposing  an additional option to match all of the partitions of the device : regex match in addition to exact match.  I thought about leaving existing behavior of BLACKLIST configuration in case someone wants to list ignored devices explicitly. 

Please see sample log for the configuration:

```
BLACKLIST='ada0'
BLACKLIST_REGEX=true
```
```
2023-01-16 14:07:54 /dev/ada0p1: device blocked by BLACKLIST regex option
2023-01-16 14:07:54 /dev/ada0p2: device blocked by BLACKLIST regex option
```